### PR TITLE
Update dependencies in line with #143

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,6 @@ dependencies = [
     "brainglobe-utils >=0.2.7",
     "imio",
     "napari >=0.4.5",
-    "npe2",
     "numpy",
     "pandas[hdf5]",
     "qtpy",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,11 +26,10 @@ dependencies = [
     "napari >=0.4.5",
     "npe2",
     "numpy",
-    "pandas",
+    "pandas[hdf5]",
     "qtpy",
     "scikit-image",
     "scipy",
-    "tables",                       # Needed for pandas imports to succeed.
     "tifffile",
 ]
 license = { text = "BSD-3-Clause" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,15 +19,16 @@ classifiers = [
 ]
 requires-python = ">=3.9"
 dependencies = [
+    "brainglobe-napari-io >= 0.3.0",
+    "dask >= 2.15.0",
+    "imio",
+    "brainglobe-utils >=  0.2.7",
+    "napari-plugin-engine >= 0.1.4",
+    "napari>=0.4.5",
     "numpy",
-    "scipy",
-    "napari >=0.4.5",
-    "qtpy",
     "pandas",
     "scikit-image",
-    "tifffile",
-    "bg-atlasapi",
-    "brainglobe-utils >=0.2.7",
+    "tables",
 ]
 license = { text = "BSD-3-Clause" }
 dynamic = ["version"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,6 @@ dependencies = [
     "bg-atlasapi",
     "brainglobe-napari-io >=0.3.0",
     "brainglobe-utils >=0.2.7",
-    "dask >= 2.15.0",
     "imio",
     "napari >=0.4.5",
     "npe2",
@@ -31,7 +30,7 @@ dependencies = [
     "qtpy",
     "scikit-image",
     "scipy",
-    "tables",
+    "tables",                       # Needed for pandas imports to succeed.
     "tifffile",
 ]
 license = { text = "BSD-3-Clause" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,16 +19,15 @@ classifiers = [
 ]
 requires-python = ">=3.9"
 dependencies = [
-    "brainglobe-napari-io >= 0.3.0",
-    "dask >= 2.15.0",
-    "imio",
-    "brainglobe-utils >=  0.2.7",
-    "napari-plugin-engine >= 0.1.4",
-    "napari>=0.4.5",
     "numpy",
+    "scipy",
+    "napari >=0.4.5",
+    "qtpy",
     "pandas",
     "scikit-image",
-    "tables",
+    "tifffile",
+    "bg-atlasapi",
+    "brainglobe-utils >=0.2.7",
 ]
 license = { text = "BSD-3-Clause" }
 dynamic = ["version"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,6 @@ dependencies = [
     "dask >= 2.15.0",
     "imio",
     "napari >=0.4.5",
-    "napari-plugin-engine >= 0.1.4",
     "npe2",
     "numpy",
     "pandas",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,16 +19,21 @@ classifiers = [
 ]
 requires-python = ">=3.9"
 dependencies = [
-    "brainglobe-napari-io >= 0.3.0",
+    "bg-atlasapi",
+    "brainglobe-napari-io >=0.3.0",
+    "brainglobe-utils >=0.2.7",
     "dask >= 2.15.0",
     "imio",
-    "brainglobe-utils >=  0.2.7",
+    "napari >=0.4.5",
     "napari-plugin-engine >= 0.1.4",
-    "napari>=0.4.5",
+    "npe2",
     "numpy",
     "pandas",
+    "qtpy",
     "scikit-image",
+    "scipy",
     "tables",
+    "tifffile",
 ]
 license = { text = "BSD-3-Clause" }
 dynamic = ["version"]


### PR DESCRIPTION
Closes #143.

Adds explicit dependencies and removes outdated dependencies.

- `brainglobe-napari-io` is needed, but never imported. See Adam's [comment here](https://github.com/brainglobe/brainglobe-segmentation/pull/144#issuecomment-1798223097).
- `pytables` is needed as a `pandas` extra, so we now depend on `pandas[hdf5]` which will fetch `pytables`.
- `dask` has been removed as a dependency.
- `napari-plugin-engine` has been removed as a dependency.
- `scipy`, `bg-atlasapi`, `tifffile`, `qtpy`, have been added as explicit dependencies.

Once merged we should tag v1.0.1 so that the team over on `conda-forge` also receive the update.