### PR TITLE
Test job now requires linting

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -15,6 +15,7 @@ jobs:
       - uses: neuroinformatics-unit/actions/lint@v1
 
   test:
+    needs: [linting]
     name: ${{ matrix.os }} py${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
     strategy:


### PR DESCRIPTION
Adding linting as a requirement for the test job to start. Previously, a release could happen with linting not passing as it was never required for any other job to start.
