### PR TITLE
Update imio dependency change

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -13,7 +13,7 @@ jobs:
   linting:
     runs-on: ubuntu-latest
     steps:
-      - uses: neuroinformatics-unit/actions/lint@v1
+      - uses: neuroinformatics-unit/actions/lint@v2
 
   manifest:
     name: Check Manifest
@@ -48,7 +48,7 @@ jobs:
       # Helps set up VTK with a headless display
       - uses: pyvista/setup-headless-display-action@v2
       # Run tests
-      - uses: neuroinformatics-unit/actions/test@v1
+      - uses: neuroinformatics-unit/actions/test@v2
         with:
           python-version: ${{ matrix.python-version }}
           use-xvfb: true
@@ -59,7 +59,7 @@ jobs:
     if: github.event_name == 'push' && github.ref_type == 'tag'
     runs-on: ubuntu-latest
     steps:
-    - uses: neuroinformatics-unit/actions/build_sdist_wheels@v1
+    - uses: neuroinformatics-unit/actions/build_sdist_wheels@v2
 
 
   upload_all:

--- a/brainglobe_segmentation/regions/IO.py
+++ b/brainglobe_segmentation/regions/IO.py
@@ -2,8 +2,8 @@ from pathlib import Path
 
 import numpy as np
 from brainglobe_utils.general.pathlib import append_to_pathlib_stem
-from brainglobe_utils.IO.surfaces import marching_cubes_to_obj
 from brainglobe_utils.image_io import to_tiff
+from brainglobe_utils.IO.surfaces import marching_cubes_to_obj
 from skimage import measure
 
 

--- a/brainglobe_segmentation/regions/IO.py
+++ b/brainglobe_segmentation/regions/IO.py
@@ -1,9 +1,9 @@
 from pathlib import Path
 
-import imio
 import numpy as np
 from brainglobe_utils.general.pathlib import append_to_pathlib_stem
 from brainglobe_utils.IO.surfaces import marching_cubes_to_obj
+from brainglobe_utils.image_io import to_tiff
 from skimage import measure
 
 
@@ -97,7 +97,7 @@ def save_regions_to_file(
     name = label_layer.name
 
     filename = destination_directory / (name + image_extension)
-    imio.to_tiff(data.astype(np.int16), filename)
+    to_tiff(data.astype(np.int16), filename)
 
 
 def export_regions_to_file(image, filename, voxel_size, ignore_empty=True):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,8 +20,7 @@ requires-python = ">=3.9"
 dependencies = [
     "bg-atlasapi",
     "brainglobe-napari-io >=0.3.0",
-    "brainglobe-utils >=0.2.7",
-    "imio",
+    "brainglobe-utils >=0.4.0",
     "napari >=0.4.5",
     "numpy",
     "pandas[hdf5]",
@@ -114,5 +113,4 @@ deps =
     magicgui
 
 commands = pytest -v --color=yes --cov=brainglobe_segmentation --cov-report=xml
-
 """


### PR DESCRIPTION
As per https://github.com/brainglobe/BrainGlobe/issues/64

`imio` will be merged into `brainglobe-utils` `v0.4.0` and thus we should update this package's dependency accordingly.

CI will fail until `brainglobe-utils` version 0.4.0 is available on PyPI.