### PR TITLE
Add header from brainglobe-utils

### DIFF
--- a/brainglobe_segmentation/segment.py
+++ b/brainglobe_segmentation/segment.py
@@ -5,6 +5,7 @@ import napari
 import numpy as np
 from brainglobe_utils.qtpy.dialog import display_warning
 from brainglobe_utils.qtpy.interaction import add_button
+from brainglobe_utils.qtpy.logo import header_widget
 from napari.qt.threading import thread_worker
 from qtpy import QtCore
 from qtpy.QtWidgets import QFileDialog, QGridLayout, QGroupBox, QLabel, QWidget
@@ -112,12 +113,13 @@ class SegmentationWidget(QWidget):
         self.layout.setAlignment(QtCore.Qt.AlignTop)
         self.layout.setSpacing(4)
 
-        # 3 Steps:
+        # 4 Steps:
+        # - header
         # - Loading panel
         # - Segmentation methods panel
         # -> Individual segmentation methods (which are invisible at first)
         # - Saving panel
-
+        self.add_header()
         self.add_loading_panel(1)
         self.add_segmentation_methods_panel(1)
         self.track_seg.add_track_panel(2)  # Track segmentation subpanel
@@ -132,6 +134,22 @@ class SegmentationWidget(QWidget):
         self.setLayout(self.layout)
 
     # PANELS ###############################################################
+
+    def add_header(self):
+        """
+        Header including brainglobe logo and documentation links.
+        """
+        # <br> is included in the package_name to make the label under the logo
+        # more compact, by splitting it onto two lines
+        header = header_widget(
+            package_name="brainglobe-<br>segmentation",
+            package_tagline="Segmentation of anatomical structures",
+            documentation_path="brainglobe-segmentation/user-guide/index.html",
+            github_repo_name="brainglobe-segmentation",
+            citation_doi="https://doi.org/10.1038/s41598-021-04676-9",
+            help_text="For help, hover the cursor over each parameter.",
+        )
+        self.layout.addWidget(header, 0, 0, 1, 2)
 
     def add_segmentation_methods_panel(self, row, column=1):
         """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ requires-python = ">=3.9"
 dependencies = [
     "brainglobe-atlasapi >=2.0.1",
     "brainglobe-napari-io >=0.3.0",
-    "brainglobe-utils >=0.4.0",
+    "brainglobe-utils >=0.4.3",
     "napari >=0.4.5",
     "numpy",
     "pandas[hdf5]",


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [ ] Addition of a new feature
- [X] Other

**Why is this PR needed?**
Currently, the `brainglobe-segmentation` widget has no header (i.e. no brainglobe logo / documentation links...).

**What does this PR do?**
This PR adds a header from `brainglobe-utils`:
![Screenshot 2024-04-12 115632](https://github.com/brainglobe/brainglobe-segmentation/assets/24316371/49115914-fbe7-4669-bc89-265a8d54ce71)

## References

For https://github.com/brainglobe/cellfinder/issues/327

## How has this PR been tested?

All tests pass locally.

## Is this a breaking change?

No

## Does this PR require an update to the documentation?

No

## Checklist:

- [X] The code has been tested locally
- [X] Tests have been added to cover all new functionality (unit & integration)
- [X] The documentation has been updated to reflect any changes
- [X] The code has been formatted with [pre-commit](https://pre-commit.com/)
