### PR TITLE
Remove command-line entry point and simplify pyproject.toml

### DIFF
--- a/brainglobe_segmentation/layout/gui_constants.py
+++ b/brainglobe_segmentation/layout/gui_constants.py
@@ -1,6 +1,4 @@
 # Constants used throughout
-WINDOW_HEIGHT = 750
-WINDOW_WIDTH = 1500
 COLUMN_WIDTH = 150
 
 DISPLAY_REGION_INFO = (

--- a/brainglobe_segmentation/segment.py
+++ b/brainglobe_segmentation/segment.py
@@ -19,8 +19,6 @@ from brainglobe_segmentation.layout.gui_constants import (
     LOADING_PANEL_ALIGN,
     SEGM_METHODS_PANEL_ALIGN,
     TRACK_FILE_EXT,
-    WINDOW_HEIGHT,
-    WINDOW_WIDTH,
 )
 from brainglobe_segmentation.paths import Paths
 from brainglobe_segmentation.regions.IO import (
@@ -560,16 +558,3 @@ def save_all(
             track_file_extension=track_file_extension,
         )
     print("Finished!\n")
-
-
-def main():
-    print("Loading segmentation GUI.\n ")
-    with napari.gui_qt():
-        viewer = napari.Viewer()  # title="Segmentation GUI")
-        viewer.window.resize(WINDOW_WIDTH, WINDOW_HEIGHT)
-        widget = SegmentationWidget(viewer)
-        viewer.window.add_dock_widget(widget, name="General", area="right")
-
-
-if __name__ == "__main__":
-    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,13 +53,7 @@ dev = [
 ]
 
 [project.entry-points."napari.manifest"]
-cellfinder-napari = "brainglobe_segmentation:napari.yaml"
-
-[project.scripts]
-brainglobe-segmentation = "brainglobe_segmentation.segment:main"
-
-[project.entry-points."napari.plugin"]
-brainglobe-segmentation = "brainglobe_segmentation.plugins"
+brainglobe-segmentation = "brainglobe_segmentation:napari.yaml"
 
 [build-system]
 requires = ["setuptools>=45", "wheel", "setuptools_scm[toml]>=6.2"]


### PR DESCRIPTION
There were many napari-related entry points in the `pyproject.toml`. I _think_ these aren't needed, so I've streamlined them. 