### PR TITLE
Pinned numpy to < 2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     "brainglobe-napari-io >=0.3.0",
     "brainglobe-utils >=0.5.0",
     "napari >=0.4.5",
-    "numpy",
+    "numpy < 2.0",
     "pandas[hdf5]",
     "qtpy",
     "scikit-image",


### PR DESCRIPTION
Before submitting a pull request (PR), please read the [contributing guide](https://github.com/brainglobe/.github/blob/main/CONTRIBUTING.md).

Please fill out as much of this template as you can, but if you have any problems or questions, just leave a comment and we will help out :)

## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
Tests were failing due to issues relating to numpy>=2.0.

**What does this PR do?**
Temporarily pin numpy < 2.0.

## References

Please reference any existing issues/PRs that relate to this PR.

## How has this PR been tested?
All tests pass when run locally in a fresh environment with numpy 1.26.3

## Is this a breaking change?
No

## Does this PR require an update to the documentation?
No=

## Checklist:

- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality (unit & integration)
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
