### PR TITLE
Schedule weekly tests

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -7,6 +7,9 @@ on:
     tags:
       - 'v*'
   pull_request:
+  schedule:
+  # Runs at 6:10am UTC on Monday
+    - cron: '10 6 * * 1'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Schedule tests to run weekly to make sure there are no installation issues, and to keep the cache fresh.