### PR TITLE
Update Python versions to adhere to SPEC 0

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -33,15 +33,15 @@ jobs:
       matrix:
         # Run all supported Python versions on linux
         os: [ubuntu-latest]
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.11", "3.12", "3.13"]
         # Include one windows and two macOS (intel based and arm based) runs
         include:
           - os: macos-13
-            python-version: "3.12"
+            python-version: "3.13"
           - os: macos-latest
-            python-version: "3.12"
+            python-version: "3.13"
           - os: windows-latest
-            python-version: "3.12"
+            python-version: "3.13"
 
     steps:
       - name: Cache brainglobe directory

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,11 +13,11 @@ classifiers = [
     "Operating System :: OS Independent",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
 ]
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 dependencies = [
     "brainglobe-atlasapi >=2.0.1",
     "brainglobe-napari-io >=0.3.0",
@@ -69,7 +69,7 @@ include = ["brainglobe_segmentation*"]
 [tool.setuptools_scm]
 
 [tool.black]
-target-version = ['py310','py311', 'py312']
+target-version = ['py311','py312', 'py313']
 skip-string-normalization = false
 line-length = 79
 
@@ -85,13 +85,13 @@ select = ["I", "E", "F"]
 legacy_tox_ini = """
 # For more information about tox, see https://tox.readthedocs.io/en/latest/
 [tox]
-envlist = py{310,311,312}
+envlist = py{311,312,313}
 
 [gh-actions]
 python =
-    3.10: py310
     3.11: py311
     3.12: py312
+    3.13: py313
 
 [testenv]
 passenv =


### PR DESCRIPTION
qt-niu is only available for SPEC 0 Python versions (3.11-3.13). This will break the conda-forge process when it's added as a dependency. Now seemed like a good idea to update the supported versions here, as (as far as I know) all the dependencies support 3.13.