### PR TITLE
Fixed white space in test_and_deploy.yml

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -73,7 +73,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
           secret-codecov-token: ${{ secrets.CODECOV_TOKEN }}
           tox-args: '-e napari-dev'
-use-xvfb: true
+          use-xvfb: true
 
       - name: Notify slack on scheduled failure
         if: failure() && github.event_name == 'schedule'


### PR DESCRIPTION
Currently, `.github/workflows/test_and_deploy.yml` fails linting due to errors in white space.

